### PR TITLE
Fix: Use absLangURL for theme credit link in footer

### DIFF
--- a/website/themes/neo/layouts/partials/footer.html
+++ b/website/themes/neo/layouts/partials/footer.html
@@ -3,7 +3,7 @@
     <p>&copy; {{ now.Format "2006" }} {{ .Site.Title }}. All rights reserved.</p>
     <p>Powered by <a href="https://gohugo.io/" target="_blank" rel="noopener" class="text-logo-accent-teal hover:underline">Hugo</a> &amp; the Neo Theme.</p>
     <p class="mt-2">
-      <a href="{{ "/neo-theme/" | relLangURL }}" class="text-logo-accent-cyan hover:underline">Neo Theme Palette</a>
+      <a href="{{ "/neo-theme/" | absLangURL }}" class="text-logo-accent-cyan hover:underline">Neo Theme Palette</a>
     </p>
   </div>
 </footer>


### PR DESCRIPTION
This ensures the link works correctly when the site is deployed to a subdirectory (e.g., GitHub Pages) or a custom domain.